### PR TITLE
adds pageview tests. require documenturl

### DIFF
--- a/src/Google.Analytics.SDK.Core/Hits/WebHits/PageViewHitBase.cs
+++ b/src/Google.Analytics.SDK.Core/Hits/WebHits/PageViewHitBase.cs
@@ -1,5 +1,7 @@
 ﻿// Copyright (c) Linda Lawton. All rights reserved.
 // Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
 using Google.Analytics.SDK.Core.Helper;
 
 namespace Google.Analytics.SDK.Core.Hits.WebHits
@@ -9,6 +11,8 @@ namespace Google.Analytics.SDK.Core.Hits.WebHits
         protected PageViewHitBase() 
         {
             HitType = HitTypes.Pageview;
+            // Google analytics does not require any special paramaters to be sent for a pageview hit.
+            // Personally I think documentLocationUrl should be set always.
             DocumentLocationURL = "(not set)";
         }
 
@@ -34,6 +38,9 @@ namespace Google.Analytics.SDK.Core.Hits.WebHits
 
         protected override bool InternalValidate()
         {
+            if (!string.IsNullOrWhiteSpace(DocumentLocationURL)) return true;
+
+            Console.WriteLine($"Required paramater missing. DocumentLocationURL={DocumentLocationURL}");
             return false;
         }
 

--- a/tests/Google.Analytics.SDK.Tests/HitTests/PageTests.cs
+++ b/tests/Google.Analytics.SDK.Tests/HitTests/PageTests.cs
@@ -1,0 +1,58 @@
+using Google.Analytics.SDK.Core.Hits.WebHits;
+using Xunit;
+
+namespace Google.Analytics.SDK.Tests.HitTests
+{
+    public class PageTests
+    {
+        [Fact]
+        public void Create_PageViewHit_All_Validate_Success()
+        {
+            var hit = new PageViewHit("https://plus.google.com/u/0/+LindaLawton/posts/7oxAdszKB9C", "https://plus.google.com", "/u/0/+LindaLawton/posts/7oxAdszKB9C", "Welcome to my Developing with Google Collection");
+
+            Assert.True(hit.Validate());
+        }
+
+        [Fact]
+        public void Create_PageViewHit_NoTitle_Validate_Success()
+        {
+            var hit = new PageViewHit("https://plus.google.com/u/0/+LindaLawton/posts/7oxAdszKB9C", "https://plus.google.com", "/u/0/+LindaLawton/posts/7oxAdszKB9C");
+
+            Assert.True(hit.Validate());
+        }
+
+        [Fact]
+        public void Create_PageViewHit_NoDocumentPath_Validate_Success()
+        {
+            var hit = new PageViewHit("https://plus.google.com/u/0/+LindaLawton/posts/7oxAdszKB9C", "https://plus.google.com");
+
+            Assert.True(hit.Validate());
+        }
+
+        [Fact]
+        public void Create_PageViewHit_No_DocumentHostName_Validate_Success()
+        {
+            var hit = new PageViewHit("https://plus.google.com/u/0/+LindaLawton/posts/7oxAdszKB9C");
+
+            Assert.True(hit.Validate());
+        }
+
+        [Fact]
+        public void Create_PageViewHit_No_DocumentURL_Validate_Success()
+        {
+            var hit = new PageViewHit();
+
+            Assert.True(hit.Validate());
+        }
+
+
+        [Fact]
+        public void Create_PageviewHit_Validate_Fail()
+        {
+            var hit = new PageViewHit();
+            hit.DocumentLocationURL = null;
+            Assert.False(hit.Validate());
+        }
+
+    }
+}


### PR DESCRIPTION
1. Adds test for pageview hits.
2. adds validate on doucmenturl is set.  

Document url is not required by google but i think its stupid to send a pageview hit without the location.