### PR TITLE
adds ContentGroup support

### DIFF
--- a/src/Google.Analytics.SDK.Core/Extensions/PropertyInfoExtensions.cs
+++ b/src/Google.Analytics.SDK.Core/Extensions/PropertyInfoExtensions.cs
@@ -10,6 +10,7 @@ namespace Google.Analytics.SDK.Core.Extensions
         {
             return property.PropertyType == typeof(IList<CustomDimenison>) ||
                    property.PropertyType == typeof(IList<CustomMetric>) ||
+                   property.PropertyType == typeof(IList<ContentGroup>) ||
                    property.PropertyType == typeof(string) ||
                    property.PropertyType == typeof(int) ||
                    property.PropertyType == typeof(long) ||

--- a/src/Google.Analytics.SDK.Core/Google.Analytics.SDK.Core.csproj
+++ b/src/Google.Analytics.SDK.Core/Google.Analytics.SDK.Core.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.0.4-beta</Version>
+    <Version>1.0.5-beta</Version>
     <PackageId>Daimto.Google.Analytics.Tracker.SDK</PackageId>
     <Authors>Linda Lawton</Authors>
     <Company>Daimto</Company>
@@ -21,7 +21,7 @@ Supported Platforms:
     <PackageProjectUrl>https://github.com/LindaLawton/google-analytics-dotnet-sdk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/LindaLawton/google-analytics-dotnet-sdk</RepositoryUrl>
     <PackageTags>Google analytics tracker measurement protocol</PackageTags>
-    <PackageReleaseNotes>adds isvalid for debug response.</PackageReleaseNotes>
+    <PackageReleaseNotes>adds support for ContentGroup</PackageReleaseNotes>
     <PackageIconUrl>https://raw.githubusercontent.com/LindaLawton/google-analytics-dotnet-sdk/master/images/analyticsicon.png</PackageIconUrl>
   </PropertyGroup>
 

--- a/src/Google.Analytics.SDK.Core/Hits/CustomProperties/ContentGroupParmBase.cs
+++ b/src/Google.Analytics.SDK.Core/Hits/CustomProperties/ContentGroupParmBase.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Google.Analytics.SDK.Core.Hits.CustomProperties
+{
+    public class ContentGroupParmBase
+    {
+        public string Value { get; set; }
+        public int Number { get; set; }
+        public ContentGroupParmBase(int number)
+        {
+            if (number < 1 || number > 5) throw new ArgumentOutOfRangeException(nameof(number), "Number must be between 1 - 5");
+            Number = number;
+        }
+    }
+}

--- a/src/Google.Analytics.SDK.Core/Hits/CustomProperties/CustomDimenison.cs
+++ b/src/Google.Analytics.SDK.Core/Hits/CustomProperties/CustomDimenison.cs
@@ -12,4 +12,14 @@ namespace Google.Analytics.SDK.Core.Hits.CustomProperties
 
         public string Value { get; set; }
     }
+
+
+    public class ContentGroup : ContentGroupParmBase
+    {
+        public ContentGroup(int number, string value) : base(number)
+        {
+            if (string.IsNullOrWhiteSpace(value)) throw new ArgumentOutOfRangeException(nameof(value), "Value must be set.");
+            Value = value;
+        }
+    }
 }

--- a/tests/Google.Analytics.SDK.Tests/HitTests/ContentGroupDimensionTests.cs
+++ b/tests/Google.Analytics.SDK.Tests/HitTests/ContentGroupDimensionTests.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using System.Linq;
+using Google.Analytics.SDK.Core;
+using Google.Analytics.SDK.Core.Extensions;
+using Google.Analytics.SDK.Core.Hits;
+using Google.Analytics.SDK.Core.Hits.WebHits;
+using Google.Analytics.SDK.Core.Services.Interfaces;
+using Xunit;
+
+namespace Google.Analytics.SDK.Tests.HitTests
+{
+    public class ContentGroupDimensionTests
+    {
+        private const string DocumentLocationUrl = "https://plus.google.com/u/0/+LindaLawton/posts/7oxAdszKB9C";
+        private const int CustomPropertyNumber = 1;
+        private const int CustomPropertyNumberInvalid = 400;
+        private const string CustomPropertyValue = "hello";
+        private const string CustomPropertyNullValue = null;
+        private const string WebPropertyId = "UA-1111-1";
+        private const string GACustomPropertyName = "cg";
+
+        public HitBase MockHit()
+        {
+            return new PageViewHit(DocumentLocationUrl);
+        }
+
+        public GaTracker MockTracker()
+        {
+            return TrackerBuilder.BuildWebTracker(WebPropertyId);
+        }
+
+        public string MockCustomProperty()
+        {
+            return $"{GACustomPropertyName}{CustomPropertyNumber}={CustomPropertyValue}";
+        }
+
+        [Fact]
+        public void CreateHitRequest_with_CustomProperty()
+        {
+            var tracker = MockTracker();
+            var hit = MockHit();
+            hit.AddContentGroup(CustomPropertyNumber, CustomPropertyValue);
+            var request = (HitRequestBase)tracker.CreateHitRequest(hit);
+            Assert.Contains(MockCustomProperty(), request.QueryString, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [Fact]
+        public void Hit_Add_CustomProperty_Test_Property_String_Build()
+        {
+            var hit = MockHit();
+            hit.AddContentGroup(CustomPropertyNumber, CustomPropertyValue);
+            Assert.Equal(hit.ContentGroup?.FirstOrDefault(d => CustomPropertyNumber.Equals(d.Number) && CustomPropertyValue.Equals(d.Value))?.Number, CustomPropertyNumber);
+        }
+
+        [Fact]
+        public void Hit_Add_CustomProperty_Duplicate_Number_Fail()
+        {
+            var hit = MockHit();
+            hit.AddContentGroup(CustomPropertyNumber, CustomPropertyValue);
+            Assert.Throws<ArgumentOutOfRangeException>(() => hit.AddContentGroup(CustomPropertyNumber, CustomPropertyValue));
+        }
+
+        [Fact]
+        public void Hit_Add_CustomProperty_NullValue_Fail()
+        {
+            var hit = MockHit();
+            Assert.Throws<ArgumentOutOfRangeException>(() => hit.AddContentGroup(CustomPropertyNumber, CustomPropertyNullValue));
+        }
+
+        [Fact]
+        public void Hit_Add_CustomProperty_ToBigNumber_Fail()
+        {
+            var hit = MockHit();
+            Assert.Throws<ArgumentOutOfRangeException>(() => hit.AddContentGroup(CustomPropertyNumberInvalid, CustomPropertyValue));
+        }
+    }
+}


### PR DESCRIPTION
adds method for adding content groups
- AddContentGroup(int id, string value)
- Unit tests for content groups.  ([cg](https://developers.google.com/analytics/devguides/collection/protocol/v1/parameters#cg_))